### PR TITLE
Update DefaultMethodCallHandler.java

### DIFF
--- a/src/main/java/com/opencredo/proxology/handlers/DefaultMethodCallHandler.java
+++ b/src/main/java/com/opencredo/proxology/handlers/DefaultMethodCallHandler.java
@@ -14,14 +14,17 @@ final class DefaultMethodCallHandler {
     private DefaultMethodCallHandler() {
     }
 
-    private static final Function<Method, MethodCallHandler> CACHE = Memoizer.memoize(m -> {
+//    private static final Function<Method, MethodCallHandler> CACHE = Memoizer.memoize(m -> {
+//        MethodHandle handle = getMethodHandle(m);
+
+//        return (proxy, args) -> handle.bindTo(proxy).invokeWithArguments(args);
+//   });
+
+    public static MethodCallHandler forMethod(Method method) {
+//        return CACHE.apply(method);
         MethodHandle handle = getMethodHandle(m);
 
         return (proxy, args) -> handle.bindTo(proxy).invokeWithArguments(args);
-    });
-
-    public static MethodCallHandler forMethod(Method method) {
-        return CACHE.apply(method);
     }
 
     private static MethodHandle getMethodHandle(Method method) {


### PR DESCRIPTION
Original code could cause dead loop in ConcurrentHashMap#computeIfAbsent, you could see the effect just by running below code
```
        ConcurrentHashMap<String,Object> cache = new ConcurrentHashMap();
        cache.computeIfAbsent("display", k1->cache.computeIfAbsent("display", k2->new Object()));
```